### PR TITLE
Generating abandoned worlds

### DIFF
--- a/clean_data.R
+++ b/clean_data.R
@@ -45,7 +45,7 @@ for(i in 1:xml_length(planets)) {
    
   # Check for connector
   name <- xml_text(xml_find_first(planet, "name"))
-  if(grepl("^(DPR|ER|KC|TFS|NP|NC|HL|JF|Interstellar Expeditions|Cambridge Perimeter Defense)", name)) {
+  if(grepl("^(DPR|ER|KC|TFS|NP|NC|HL|JF|Interstellar Expeditions|Cambridge Perimeter Defense|RWR Outpost|Transfer Station|Wolf Orbital|Transfer Facility)", name)) {
      xml_add_child(connectors, planet)
      next
   }

--- a/functions/data_functions.R
+++ b/functions/data_functions.R
@@ -1,5 +1,7 @@
 #some useful functions for dealing with data processing
 
+#### Functions for processing initial XML data ####
+
 #return planet nodeset by id. This can be used on 
 #planets or planetevents file
 get_planet_id <- function(full_xml, id) {
@@ -56,11 +58,6 @@ get_closest_event <- function(event_table, chosen_date, min_date=NA, allow_later
   return(as.character(event_table$event[which(date_diff==max(date_diff[date_diff<=0]))[1]]))
 }
 
-#extract the year from a date object as numeric
-get_year <- function(date) {
-  as.numeric(format(date,'%Y'))
-}
-
 #### Functions for post processing into systems ####
 
 get_system_id <- function(full_xml, id) {
@@ -73,4 +70,120 @@ get_planet_in_system <- function(full_xml, id, pos) {
   system <- systems[which(xml_text(xml_find_first(systems, "id"))==id)]
   planets <- xml_find_all(system, "planet")
   return(planets[which(xml_text(xml_find_first(planets, "sysPos"))==pos)][[1]])
+}
+
+#### Functions for dealing with universe data ####
+
+#extract the year from a date object as numeric
+get_year <- function(date) {
+  as.numeric(format(date,'%Y'))
+}
+
+get_faction_type <- function(faction) {
+  faction_type <- "Minor"
+  if(faction=="CC" | faction=="DC" | faction=="FS" | faction=="LA" |
+     faction=="FWL" |
+     faction=="FC" | faction=="FRR" | faction=="SIC" | faction=="MERC" |
+     faction=="CS") {
+    faction_type <- "IS"
+  }
+  if(faction=="CBS" | faction=="CB" | faction=="CCC" | faction=="CCO" |
+     faction=="CDS" | faction=="CFM" | faction=="CGB" | faction=="CGS" |
+     faction=="CGS" | faction=="CHH" | faction=="CIH" | faction=="CJF" | 
+     faction=="CMG" | faction=="CNC" | faction=="CSJ" | faction=="CSR" | 
+     faction=="CSA" | faction=="CSV" | faction=="CSL" | faction=="CWI" |
+     faction=="CW" | faction=="CLAN") {
+    faction_type <- "Clan"
+  }
+  if(faction=="TC" | faction=="OA" | faction=="MOC" | faction=="MH") {
+    faction_type <- "Periphery"
+  }
+  faction_type <- factor(faction_type)
+  return(faction_type)
+}
+
+fix_founding_heaping <- function(founding_year) {
+  # The following dates showed evidence of heaping and need to be corrected. We ignore
+  # some potential small heaping cases for small year intervals.
+  
+  # 2172 - 131 cases. not from known SUCS map change, but clear heaping, distibute these
+  #cases between 2118 and 2172
+  # 2200 - 42 cases. not from known SUCS map change, but clear heaping, distribute these cases
+  # between 2173 and 2200
+  # 2271 - 232 cases. First SUCS map. Distributed these cases between 2118 and 2271. 
+  # 2300 - 212 cases. not from known SUCS map change, but clear heaping, distribute these cases 
+  # between 2201 and 2300
+  # 2317 - 49 cases. SUCS map. Distribute these cases between 2272 and 2317.
+  # 2367 - 43 cases. SUCS map. Distribute these cases between 2342 and 2367.
+  # 2571 - 238 cases. SUCS map. Distribute these cases between 2368 and 2571.
+  # 2750 - 531 cases. SUCS map. Distributed these cases between 2597 and 2750.
+  
+  #remaining heaps seem to be clans, hanseatic league, and back part of TC, not
+  #adjusting them for now. 
+  if(founding_year==2172) {
+    founding_year <- sample(2118:2172, 1)
+  }
+  if(founding_year==2200) {
+    founding_year <- sample(2173:2200, 1)
+  }
+  if(founding_year==2300) {
+    founding_year <- sample(2201:2300, 1)
+  }
+  if(founding_year==2271) {
+    founding_year <- sample(2118:2271, 1)
+  }
+  if(founding_year==2317) {
+    founding_year <- sample(2272:2317, 1)
+  }
+  if(founding_year==2367) {
+    founding_year <- sample(2342:2367, 1)
+  }
+  if(founding_year==2571) {
+    founding_year <- sample(2368:2571, 1)
+  }
+  if(founding_year==2750) {
+    founding_year <- sample(2597:2750, 1)
+  }
+  return(founding_year)
+}
+
+fix_abandoned_heaping <- function(abandon_year, founding_year) {
+  if(is.na(abandon_year)) {
+    return(abandon_year)
+  }
+  #2821 and 2822: end of the 1SW, so these should probably be distributed throughout the 1SW. 
+  #There are also quite a few at 2822 including Lone Star which definitely died during 1SW.
+  #2864: end of the 2SW, so distribute throughout 2SW.
+  #2888: Not sure what this, but maybe a map related difference? Distribute between end of 2SW and 2888.
+  #2900-2985. A lot of things on the 10s and 5s and a huge group at 2925. Probably distribute immediately 
+  #proceeding 5 years.
+  #3025: Distribute between 3000-3025.
+  abandon_new <- NA
+  if(abandon_year==2821 | abandon_year==2822) {
+    abandon_new <- sample(2786:2822, 1)
+  }
+  if(abandon_year==2864) {
+    abandon_new <- sample(2830:2864, 1)
+  }
+  if(abandon_year==2888) {
+    abandon_new <- sample(2865:2888, 1)
+  }
+  if(abandon_year>=2900 & abandon_year<=2985 & 
+     ((abandon_year %% 10)==0 | (abandon_year %% 10)==5)) {
+    abandon_new <- abandon_year-sample(0:4,1)
+  }
+  if(abandon_year==3025) {
+    abandon_new <- sample(3001:3025, 1)
+  }
+  #I need to make sure that the abandon year is never less than or equal to founding year. If I find that to 
+  #be the case, then I will just add some random number to founding year and take the minimum of that or the 
+  #original abandon year
+  if(!is.na(abandon_new)) {
+    if(abandon_new<=founding_year) {
+      abandon_year <- min(founding_year+ceiling(rexp(1,1/100)), abandon_year)
+    } else {
+      abandon_year <- abandon_new
+    }
+  } 
+  return(abandon_year)
 }

--- a/functions/network_functions.R
+++ b/functions/network_functions.R
@@ -1,7 +1,7 @@
 library(DiagrammeR)
 
 get_network <- function(hpg_data) {
-  first_circuit <- subset(hpg_data, hpg=="A" & faction_type=="IS")
+  first_circuit <- subset(hpg_data, hpg=="A" & faction_type=="IS" & is.na(abandon_year))
   outer_circuit <- subset(hpg_data, hpg!="A" & faction_type=="IS" & founding_year<2700)
   
   x <- matrix(rep(first_circuit$x, nrow(first_circuit)), 

--- a/functions/system_creation_functions.R
+++ b/functions/system_creation_functions.R
@@ -37,8 +37,8 @@ generate_system <- function(star=NULL, habitable=TRUE, habit_pos=NA) {
       if((star_size=="V" && !(habit_pos %in% which(habitable_zones$main[,star]))) |
          (star_size!="V" && !(habit_pos %in% which(habitable_zones$nonmain[,paste(spectral_class, 
                                                                                     subtype, sep="")])))) { 
-        warning(paste("Star type ", star, " is not a valid star type for a habitable planet in position ", habit_pos,
-                      ". Star type randomly generated instead.", sep=""))
+        #warning(paste("Star type ", star, " is not a valid star type for a habitable planet in position ", habit_pos,
+        #              ". Star type randomly generated instead.", sep=""))
         star <- NULL
       }
     }
@@ -54,8 +54,8 @@ generate_system <- function(star=NULL, habitable=TRUE, habit_pos=NA) {
       
       #if habit_pos is greater than 7, its impossible so make it 7
       if(!is.na(habit_pos) && habit_pos>7) {
-        warning(paste("Habitable planet suggested in position", 
-                      habit_pos, "is impossible in life zone. Changing to position 7."))
+        #warning(paste("Habitable planet suggested in position", 
+        #              habit_pos, "is impossible in life zone. Changing to position 7."))
         habit_pos <- 7
       }
       #if the habitable position is between 5 and 7, then we must roll on the 
@@ -756,7 +756,7 @@ generate_planet <- function(radius, habitable_system, system_data, more_gradatio
 
 #faction type should be either "Clan", "IS", "Periphery", "Minor"
 add_colonization <- function(system, distance_terra, current_year,
-                             founding_year, faction_type) {
+                             founding_year, faction_type, abandon_year) {
   
   faction_type <- factor(faction_type,
                          levels=c("IS","Clan","Periphery","Minor"),
@@ -809,6 +809,10 @@ add_colonization <- function(system, distance_terra, current_year,
     
     #population
     high_roll <- roll_d6(1)
+    #if this planet is abandoned, don't allow a high population 
+    if(!is.na(abandon_year)) {
+      high_roll <- 1
+    }
     
     ##Tweaks: the clan numbers are super low and produce populations of 
     ## around 245,000 on average. Based on existing numbers this is low
@@ -1172,10 +1176,9 @@ add_colonization <- function(system, distance_terra, current_year,
 
 #### Population Projection Functions ####
 
-#TODO: put some hard upper limit on population sizes (i.e. carrying capacity)
 #project population from year 3067 forwards and backwards
 project_population <- function(base_pop, found_year, faction_type, border_distance, 
-                               agriculture, terran_hegemony=FALSE,
+                               agriculture, terran_hegemony=FALSE, abandon_year=NULL,
                                p2750=NULL, p3025=NULL, p3067=NULL, p3079=NULL, p3145=NULL) {
   
   #base year is 3067
@@ -1211,7 +1214,6 @@ project_population <- function(base_pop, found_year, faction_type, border_distan
   
   #get growth to end of DA first. If there are valid 3079 or 3145 dates, but not
   #3067, then ignore current base pop and reassign at the end.
-  ##TODO: need to deal with some post 3067 foundings
   growth <- 0.001
   if(!is.null(p3079)) {
     if(!is.null(p3067)) {
@@ -1405,6 +1407,76 @@ project_population <- function(base_pop, found_year, faction_type, border_distan
   #abline(v=2785, lty=2, col="red")
   #abline(v=3029, lty=2, col="red")
   
+  if(!is.na(abandon_year)) {
+    full_pop <- project_population_abandon(full_pop, found_year,  abandon_year, faction_type)
+  }
+  
+  return(full_pop)
+}
+
+#rather than try some whole other projection from scracth for abandoned planets, we will
+#take the regular population projection results and then modify them to get abandonment
+#by the expected date. We just truncate the projection based on the abandon_year and then
+#determine how far back the depopulation begins. Once we have that number we just redo all
+#the numbers after the peak to get to zero using the average decline rate.
+project_population_abandon <- function(full_pop, found_year, abandon_year, faction_type) {
+  
+  life_span <- abandon_year-found_year
+  
+  full_pop <- full_pop[paste(found_year:abandon_year)]
+  
+  #last year is always zero
+  full_pop[paste(abandon_year)] <- 0
+  
+  #checks for really short life spans
+  base_pop <- round(50000*runif(1,0.9,1.1))
+  if(life_span==1) {
+    #that was quick
+    full_pop[paste(found_year)] <- base_pop
+    return(full_pop)
+  }
+  
+  #if lifespan is 10 or less, then just do a steady decline from 50000 to 5000 year before and then done
+  if(life_span<=10) {
+    full_pop[paste(found_year)] <- base_pop
+    rates <- c(0,growth_simulation(log(1/10)/(life_span-1),(life_span-1)))
+    full_pop[paste(found_year:abandon_year)] <- c(round(base_pop*exp(cumsum(rates))),0)
+    return(full_pop)
+  }
+  
+  #how far back should we go for the peak? This should be based on some combination of abandonment
+  #date and the life span of the colony. But there are also two scenarios to consider: (1) rapid depopulation
+  #from intense events ala Lone Star, or gradually decline and abandonment. The former will have a much shorter
+  #range between peak and abandonment, and the latter will have much longer. 
+  if(abandon_year<2750 || life_span<100 || faction_type=="Clan" || faction_type=="Minor") {
+    #assume gradual depopulation from some peak between the 25th and 75th percentile of life span
+    go_back <- round(life_span * runif(1, 0.25, 0.75))
+  } else if(abandon_year>2865 & abandon_year<3067) {
+    #3SW era. Assume a gradual decline from around start of 1SW or founding whichever is later
+    go_back <- round(min(life_span, abandon_year-2785))
+  } else if(abandon_year>=3067 & abandon_year<=3081) {
+    #for jihad abandonment the peak is at 3060
+    go_back <- abandon_year-3060
+  } else {
+    #otherwise assume rapid depopulation between 10-40 years
+    go_back <- rnorm(1,25,7)
+    while(go_back<10 || go_back>40) {
+      go_back <- rnorm(1,25,7)
+    }
+  }
+  peak_year <- abandon_year - round(go_back)
+  
+  #calculate the rate of decline
+  #assume that the year before abandonment is about 5K population on average, figure out the average depopulation rate
+  #from the peak
+  rates <- growth_simulation(log(5000/full_pop[paste(peak_year)])/(abandon_year-peak_year-1), 
+                             abandon_year-peak_year-1)
+  
+  #make this a little more gradual
+  rates[1:4] <- rates[1:4]/c(5,4,3,2)
+  
+  full_pop[paste((peak_year+1):(abandon_year-1))] <- full_pop[paste(peak_year)]*exp(cumsum(rates))
+  
   return(full_pop)
 }
 
@@ -1467,7 +1539,7 @@ get_gompertz_rates <- function(ending_pop, start_colony_size, time_length) {
 #### SICS Projection Functions ####
 
 project_sics <- function(tech, industry, raw, output, agriculture,
-                         founding_year, pop, faction_type) {
+                         founding_year, abandon_year, pop, faction_type) {
   
   sics <- list(tech=tech, industry=industry, raw=raw, output=output, 
                agriculture=agriculture)
@@ -1555,6 +1627,15 @@ project_sics <- function(tech, industry, raw, output, agriculture,
                        interpolate_sics(sics, sics_da, current_year, year_da)[-1,])
   
   
+  if(!is.na(abandon_year)) {
+    #remove all sics past the abandonment date
+    sic_changes <- subset(sic_changes, year<=abandon_year)
+    #all X on abandonment
+    sic_changes <- rbind(sic_changes,
+                         data.frame(year=abandon_year, sics="X-X-X-X-X"))
+  }
+  
+  
   return(sic_changes)
 }
 
@@ -1596,6 +1677,11 @@ get_colony_sics <- function(sics, founding_year, current_year, faction_type) {
 #or decrease for each level.
 adjust_sics <- function(sics, odds_drop, odds_increase,
                         pop_ratio=1, colony_age) {
+  
+  if(is.na(pop_ratio)) {
+    #this means no population value for this year, so just return the original sics
+    return(sics)
+  }
   
   tech <- sics$tech[1]
   industry <- sics$industry[1]
@@ -1785,7 +1871,7 @@ interpolate_sics <- function(sics_start, sics_end, start_year, end_year,
 
 ## TODO: Then need to figure out Dark Age blackout
 
-project_hpg <- function(base_hpg, distance_terra, founding_year, faction_type) {
+project_hpg <- function(base_hpg, distance_terra, founding_year, faction_type, abandon_year) {
   
   #build rate for things built right at start. Average build time is one over this
   building_time <- 0.33
@@ -1868,6 +1954,12 @@ project_hpg <- function(base_hpg, distance_terra, founding_year, faction_type) {
     
   }
   
+  if(!is.na(abandon_year)) {
+    hpg_table <- subset(hpg_table, year<abandon_year)
+    hpg_table <- rbind(hpg_table, 
+                       data.frame(year=abandon_year, hpg="X"))
+  }
+  
   return(hpg_table)
 }
 
@@ -1882,7 +1974,11 @@ project_hpg <- function(base_hpg, distance_terra, founding_year, faction_type) {
 # station at SL peak. My sense is that it should be higher than this, so lets try adding a +3 rather
 # than +2 to the adjustment.
 
-project_recharge <- function(recharge_current, faction_type, founding_year, sics_project, pop) {
+project_recharge <- function(recharge_current, faction_type, founding_year, sics_project, pop,
+                             abandon_year) {
+  
+  #remove X-X-X-X-X from sics_projects (due to abandonment) or they will cause problems
+  sics_project <- subset(sics_project, sics!="X-X-X-X-X")
   
   #default to about 50 years after colonization, on average
   build_rate <- 0.02
@@ -1945,10 +2041,15 @@ project_recharge <- function(recharge_current, faction_type, founding_year, sics
   population_sl <- pop["2765"]
 
   recharge_roll <- roll_d6(2)
-  if(population_sl>=(2*10^9)) {
-    recharge_roll <- recharge_roll+1
-  } else if(population_sl<(1*10^9)) {
+  if(is.na(population_sl)) {
+    #didn't make it to star league, so less likely
     recharge_roll <- recharge_roll-1
+  } else {
+    if(population_sl>=(2*10^9)) {
+      recharge_roll <- recharge_roll+1
+    } else if(population_sl<(1*10^9)) {
+      recharge_roll <- recharge_roll-1
+    }
   }
   if(max(tech, na.rm=TRUE)<="D") {
     recharge_roll <- recharge_roll-1
@@ -2050,6 +2151,18 @@ project_recharge <- function(recharge_current, faction_type, founding_year, sics
                          etype="nadirCharge",
                          event="false"))
     }
+  }
+  
+  if(!is.na(abandon_year)) {
+    recharge_history <- subset(recharge_history, year<abandon_year)
+    recharge_history <- recharge_history %>% 
+      bind_rows(tibble(year=abandon_year,
+                       etype="nadirCharge",
+                       event="false"))
+    recharge_history <- recharge_history %>% 
+      bind_rows(tibble(year=abandon_year,
+                       etype="zenithCharge",
+                       event="false"))
   }
   
   return(recharge_history)

--- a/functions/system_creation_functions.R
+++ b/functions/system_creation_functions.R
@@ -1181,6 +1181,17 @@ project_population <- function(base_pop, found_year, faction_type, border_distan
                                agriculture, terran_hegemony=FALSE, abandon_year=NULL,
                                p2750=NULL, p3025=NULL, p3067=NULL, p3079=NULL, p3145=NULL) {
   
+  #check to see if we are in the last year of projection
+  if(found_year==3145) {
+    if(!is.null(p3145)) {
+      base_pop <- p3145
+    } else {
+      base_pop <- round(50000*runif(1, 0.95,1.05))
+    }
+    names(base_pop) <- "3145"
+    return(base_pop)
+  }
+  
   #base year is 3067
   base_year <- 3067
   if(!is.null(p3067)) {

--- a/input/planets.xml
+++ b/input/planets.xml
@@ -26862,7 +26862,7 @@ During the First Succession War, the Draconis Combine used over a dozen 100-mega
         <temperature>0</temperature>
         <climate>ARCTIC</climate>
         <lifeForm>NONE</lifeForm>
-        <socioIndustrial>B-C-D-D-E</socioIndustrial>
+        <socioIndustrial>B-C-D-D-F</socioIndustrial>
         <hpg>X</hpg>
         <faction>UND</faction>
         <desc>The Dark Nebula Waystation was created as a logistical point for the invading Clans just outside of the Inner Sphere and has traded hands multiple times between the 3050s and 3070s, with multiple attempts made to destroy the station outright. However, the immense size of the station prevented its complete destruction, but eventually all functions beyond using the Dark Nebula as a stopover and possibly storage, were lost.</desc>

--- a/produce_systems.R
+++ b/produce_systems.R
@@ -55,15 +55,18 @@ event_table <- tibble(id=character(),
                       event=character(),
                       canon=logical())
 
+#for recolonization
 # a list of recolonization faction events for later processing
 recolonization <- list()
+# a list of primary planets for recolonization
+recolonized_planets <- list()
 
 #prepare the XML systems output
 systems <- xml_new_document() %>% xml_add_child("systems")
 systems_events <- xml_new_document() %>% xml_add_child("systems")
 systems_name_changes <- xml_new_document() %>% xml_add_child("systems")
 
-small_sample <- sample(1:xml_length(planets), 50)
+small_sample <- sample(1:xml_length(planets), 100)
 
 for(i in 1:xml_length(planets)) {
 #for(i in small_sample) {
@@ -123,6 +126,7 @@ for(i in 1:xml_length(planets)) {
   founding_year <- NA
   terran_hegemony <- FALSE
   abandon_year <- NA
+  is_recolonized <- FALSE
   if(!is.null(faction_table)) {
     founding_year <- get_year(faction_table$date[1])
     
@@ -137,12 +141,12 @@ for(i in 1:xml_length(planets)) {
         if(splits[j]==nrow(faction_table)) {
           next
         }
-        #TODO: check for re-colonization
         temp[[j]] <- faction_table[(splits[j]+1):nrow(faction_table),]
         faction_table <- faction_table[1:splits[j],]
       }
       if(length(temp)>0) {
         recolonization[[id]] <- temp
+        is_recolonized <- TRUE
       }
       
       abandon_year <- get_year(subset(faction_table, event=="ABN")$date)
@@ -161,9 +165,6 @@ for(i in 1:xml_length(planets)) {
     terran_hegemony <- grepl("(^TH$|TH,|,TH)", 
                              get_closest_event(subset(faction_table, event!="ABN"), 
                                                as.Date(paste(2750,"01","01",sep="-"))))
-    if("ABN" %in% faction_table$event) {
-      #TODO: check for heaping on abandonment date
-    }
   }
   
   hpg_table <- get_event_data(events, id, "hpg")
@@ -223,25 +224,7 @@ for(i in 1:xml_length(planets)) {
   
   distance_terra <- sqrt(x^2+y^2)
   #this would be easier to do with an %in% but not going to mess with it now
-  faction_type <- "Minor"
-  if(faction=="CC" | faction=="DC" | faction=="FS" | faction=="LA" |
-     faction=="FWL" |
-     faction=="FC" | faction=="FRR" | faction=="SIC" | faction=="MERC" |
-     faction=="CS") {
-    faction_type <- "IS"
-  }
-  if(faction=="CBS" | faction=="CB" | faction=="CCC" | faction=="CCO" |
-     faction=="CDS" | faction=="CFM" | faction=="CGB" | faction=="CGS" |
-     faction=="CGS" | faction=="CHH" | faction=="CIH" | faction=="CJF" | 
-     faction=="CMG" | faction=="CNC" | faction=="CSJ" | faction=="CSR" | 
-     faction=="CSA" | faction=="CSV" | faction=="CSL" | faction=="CWI" |
-     faction=="CW" | faction=="CLAN") {
-    faction_type <- "Clan"
-  }
-  if(faction=="TC" | faction=="OA" | faction=="MOC" | faction=="MH") {
-    faction_type <- "Periphery"
-  }
-  faction_type <- factor(faction_type)
+  faction_type <- get_faction_type(faction)
   
   #Check for bad stellar types and correct
   if(!is.na(star)) {
@@ -271,57 +254,12 @@ for(i in 1:xml_length(planets)) {
   # determined in many cases by changes between maps with the faction change only 
   # occurring at the latter date. We want to allow these founding dates to vary between
   # the map dates, probably by drawing from uniform distribution. 
- 
-  # The following dates showed evidence of heaping and need to be corrected. We ignore
-  # some potential small heaping cases for small year intervals.
+  founding_year <- fix_founding_heaping(founding_year)
   
-  # 2172 - 131 cases. not from known SUCS map change, but clear heaping, distibute these
-   #cases between 2118 and 2172
-  # 2200 - 42 cases. not from known SUCS map change, but clear heaping, distribute these cases
-  # between 2173 and 2200
-  # 2271 - 232 cases. First SUCS map. Distributed these cases between 2118 and 2271. 
-  # 2300 - 212 cases. not from known SUCS map change, but clear heaping, distribute these cases 
-  # between 2201 and 2300
-  # 2317 - 49 cases. SUCS map. Distribute these cases between 2272 and 2317.
-  # 2367 - 43 cases. SUCS map. Distribute these cases between 2342 and 2367.
-  # 2571 - 238 cases. SUCS map. Distribute these cases between 2368 and 2571.
-  # 2750 - 531 cases. SUCS map. Distributed these cases between 2597 and 2750.
-  
-  #remaining heaps seem to be clans, hanseatic league, and back part of TC, not
-  #adjusting them for now. 
-  founding_year_canon <- TRUE
-  if(founding_year==2172) {
-    founding_year <- sample(2118:2172, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2200) {
-    founding_year <- sample(2173:2200, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2300) {
-    founding_year <- sample(2201:2300, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2271) {
-    founding_year <- sample(2118:2271, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2317) {
-    founding_year <- sample(2272:2317, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2367) {
-    founding_year <- sample(2342:2367, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2571) {
-    founding_year <- sample(2368:2571, 1)
-    founding_year_canon <- FALSE
-  }
-  if(founding_year==2750) {
-    founding_year <- sample(2597:2750, 1)
-    founding_year_canon <- FALSE
-  }
+  #also check for heaping on abandon year. This function will return NA if abandon_year is NA 
+  #already. We also need to feed in founding year to make sure we don't end up with abandonment
+  #before founding
+  abandon_year <- fix_abandoned_heaping(abandon_year, founding_year)
   
   #read in canon population data
   if(id %in% rownames(canon_populations)) {
@@ -398,7 +336,6 @@ for(i in 1:xml_length(planets)) {
     xml_add_child(planet_node, "orbitalDist", 
                   planet$orbital_dis)
     
-    #TODO: asteroid belts should not count for system position
     xml_add_child(planet_node, "sysPos", j)
     
     if(j==primary_slot & !is.na(pressure)) {
@@ -558,14 +495,6 @@ for(i in 1:xml_length(planets)) {
     if(!is.na(planet$population)) {
       
       cat("\tprojections")
-      
-      #TODO: add this back into the new way events are written to XML
-      #if(founding_year_canon) {
-        #xml_add_child(current_planet_event_node, "foundYear", paste(founding_year))
-      #}  else {
-        #xml_add_child(current_planet_event_node, "foundYear", paste(founding_year),
-        #              source="noncanon")
-      #}
       
       if(!is.null(faction_table)) {
         faction_table$date[1] <- paste(founding_year,"01","01",sep="-")
@@ -768,6 +697,26 @@ for(i in 1:xml_length(planets)) {
                            event=paste(recharge_data$event),
                            canon=FALSE))
       }
+      
+      if(j==primary_slot && is_recolonized) {
+        #we need to save the planet information so that we can re-access it later for recolonization
+        planet$previous_abandon_year <- abandon_year
+        planet$border_distance <- border_distance
+        planet$terran_hegemony <- terran_hegemony
+        if(!is.na(sic)) {
+          canon_sics <- separate_sics(sic)
+          planet$tech <- canon_sics$tech
+          planet$industry <- canon_sics$industry
+          planet$raw <- canon_sics$raw
+          planet$output <- canon_sics$output
+          planet$agriculture <- canon_sics$agriculture
+        }
+        planet$nadir <- system$recharge$nadir
+        planet$zenith <- system$recharge$zenith
+        planet$distance_terra <- distance_terra
+        planet$primary_slot <- primary_slot
+        recolonized_planets[[id]] <- planet
+      }
     }
   }
   
@@ -921,9 +870,188 @@ for(i in 1:nrow(hpg_data)) {
   cat("done\n")
 }
 
+#### Handle Recolonization Cases ####
+
+cat("\nHandling Recolonization Efforts\n")
+#I am getting 56 cases of recolonization and one of those cases is a double recolonization
+recol_ids <- names(recolonization)
+for(recol_id in recol_ids) {
+  cat(recol_id)
+  recol_attempts <- recolonization[[recol_id]]
+  planet <- recolonized_planets[[recol_id]]
+  #for now just do the first one - figure out the one case of double recolonization later
+  for(i in 1:length(recol_attempts)) {
+    faction_table <- recol_attempts[[i]]
+    #some of these (e.g. Afleir) are just showing an abandoned event which makes no sense unless ABN was 
+    #in this case we have an abandoned date of 2860 and then one immediately after for 2864.
+    #added twice
+    #check for singular abandoned factions from bad data
+    if(nrow(faction_table==1) && faction_table$event[1]=="ABN") {
+      next
+    }
+    #get faction
+    temp <- get_closest_event(subset(faction_table, event!="ABN"), 
+                              target_date, allow_later = TRUE)
+    #take the first faction in cases of multiple factions
+    if(!is.na(temp)) {
+      faction <- strsplit(temp,",")[[1]][1]
+    }
+    faction_type <- get_faction_type(faction)
+    founding_year <- get_year(faction_table$date[1])
+    abandon_year <- NA
+    if("ABN" %in% faction_table$event) {
+      abandon_year <- get_year(subset(faction_table, event=="ABN")$date)
+    }
+    #read in canon population data
+    if(id %in% rownames(canon_populations)) {
+      canon_population <- canon_populations[id,]
+    } else {
+      canon_population <- NULL
+    }
+    #deal with potential founding year heaping, but be careful
+    #not to go back before previous abandonment date
+    founding_corrected <- fix_founding_heaping(founding_year)
+    if(founding_corrected != founding_year) {
+      if(!is.na(planet$previous_abandon_year) && founding_corrected<=planet$previous_abandon_year) {
+        #add around 50 years (on average) to the abandon date and take the minimum of this value and 
+        #the original founding year
+        founding_year <- min(planet$previous_abandon_year+ceiling(rexp(1,1/50)), founding_year)
+      } else {
+        founding_year <- founding_corrected
+      }
+    }
+    #now address abandon year heaping
+    abandon_year <- fix_abandoned_heaping(abandon_year, founding_year)
+    
+    ## Creat the colony
+    
+    #faction history
+    if(!is.null(faction_table)) {
+      faction_table$date[1] <- paste(founding_year,"01","01",sep="-")
+      for(i in 1:nrow(faction_table)) {
+        event_table <- event_table %>% 
+          bind_rows(tibble(id=as.character(recol_id),
+                           sys_pos=planet$primary_slot,
+                           date=as.character(faction_table$date[i]),
+                           etype="faction",
+                           event=as.character(faction_table$event[i]),
+                           canon=TRUE))
+      }
+    }
+    
+    #POPULATION
+    p2750 <- NULL
+    p3025 <- NULL
+    p3067 <- NULL
+    p3079 <- NULL
+    p3145 <- NULL
+    if(!is.null(canon_population)) {
+      if(!is.na(canon_population$X2750)) {
+        p2750 <- canon_population$X2750
+      }
+      if(!is.na(canon_population$X3025)) {
+        p3025 <- canon_population$X3025
+      }
+      if(!is.na(canon_population$X3067)) {
+        p3067 <- canon_population$X3067
+      }
+      if(!is.na(canon_population$X3079)) {
+        p3079 <- canon_population$X3079
+      }
+      if(!is.na(canon_population$X3145)) {
+        p3145 <- canon_population$X3145
+      }
+    }
+    pop <- project_population(planet$population, founding_year, faction_type,
+                              planet$border_distance, planet$agriculture, 
+                              terran_hegemony = planet$terran_hegemony,
+                              abandon_year = abandon_year,
+                              p2750 = p2750, p3025 = p3025, p3067 = p3067,
+                              p3079 = p3079, p3145 = p3145)
+    #collect population values at 10 year intervals, plus the starting and final values.
+    first_census_year <- founding_year + 10*(ceiling(founding_year/10)-(founding_year/10))
+    last_year <- as.numeric(names(pop)[length(pop)])
+    last_census_year <- 10*floor(last_year/10)
+    if(last_census_year<=first_census_year) {
+      #if colony died quickly or was founded close to 3145, this won't work so just put first population
+      event_table <- event_table %>% 
+        bind_rows(tibble(id=as.character(recol_id),
+                         sys_pos=planet$primary_slot,
+                         date=paste(founding_year,"01","01",sep="-"),
+                         etype="population",
+                         event=paste(pop[1]),
+                         canon=FALSE))
+    } else {
+      #otherwise add census years to event list 
+      census_years <- c(founding_year, seq(from=first_census_year, to=last_census_year, by=10), last_year)
+      census_pop <- round(pop[paste(census_years)])
+      event_table <- event_table %>% 
+        bind_rows(tibble(id=as.character(recol_id),
+                         sys_pos=planet$primary_slot,
+                         date=paste(census_years,"01","01",sep="-"),
+                         etype="population",
+                         event=paste(census_pop),
+                         canon=FALSE))
+    }
+    #if abandoned, add in abandonment year
+    if(!is.na(abandon_year)) {
+      event_table <- event_table %>% 
+        bind_rows(tibble(id=as.character(recol_id),
+                         sys_pos=planet$primary_slot,
+                         date=paste(abandon_year,"01","01",sep="-"),
+                         etype="population",
+                         event="0",
+                         canon=TRUE))
+    }
+    
+    #SICS
+    sics_projections <- project_sics(planet$tech, planet$industry, planet$raw, 
+                                     planet$output, planet$agriculture, 
+                                     founding_year, abandon_year, pop, faction_type)
+    event_table <- event_table %>% 
+      bind_rows(tibble(id=as.character(recol_id),
+                       sys_pos=planet$primary_slot,
+                       date=paste(sics_projections$year,"01","01",sep="-"),
+                       etype="socioIndustrial",
+                       event=paste(sics_projections$sics),
+                       canon=FALSE))
+    
+    #HPG
+    hpg_history <- project_hpg(planet$hpg, planet$distance_terra,
+                               founding_year,
+                               as.character(faction_type),
+                               abandon_year)
+    
+    #add to event_table
+    event_table <- event_table %>% 
+      bind_rows(tibble(id=as.character(recol_id),
+                       sys_pos=planet$primary_slot,
+                       date=paste(hpg_history$year,"01","01",sep="-"),
+                       etype="hpg",
+                       event=paste(hpg_history$hpg),
+                       canon=FALSE))
+    
+    #RECHARGE
+    recharge_data <- project_recharge(list(nadir=planet$nadir, zenith=planet$zenith), 
+                                      faction_type, founding_year, sics_projections,
+                                      pop, abandon_year)
+    event_table <- event_table %>% 
+      bind_rows(tibble(id=as.character(recol_id),
+                       sys_pos=0,
+                       date=paste(recharge_data$year,"01","01",sep="-"),
+                       etype=recharge_data$etype,
+                       event=paste(recharge_data$event),
+                       canon=FALSE))
+    
+  }
+  cat("\n")
+}
+cat("done\n")
+
 #### Write Event Data to XML ####
 
 cat("\nWriting event data to XML\n")
+
 
 #sort event data by id and then date
 event_table$date <- as.Date(event_table$date)

--- a/produce_systems.R
+++ b/produce_systems.R
@@ -192,7 +192,7 @@ for(i in 1:xml_length(planets)) {
   
   #TODO: need to generate data for abandoned planets too
   if(faction=="ABN") {
-    cat(paste(id, "is abandoned. Skipping.\n"))
+    warning(paste(id, "is abandoned. Skipping.\n"))
     next
   }
 


### PR DESCRIPTION
This PR changes the code base to allow for the generation of planets that have been abandoned, making adjustments to social data as necessary. It will also check for recolonization attempt(s) and generate new social data in those cases. 