### PR TITLE
Sysops mismatch

### DIFF
--- a/functions/naming_functions.R
+++ b/functions/naming_functions.R
@@ -57,7 +57,11 @@ generate_system_names <- function(system, id=NA) {
   #determine if this system has a numbering system and if so, number the planets
   use_roman_planet_numbering <- grepl("\\s+(I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV)$", 
                                       nationality$founding_name)
-  use_arabic_planet_numbering <- grepl("\\s+\\d+$", nationality$founding_name)
+  #this is problematic because of things like Star Cluster 643. It turns out only Baker 3 uses
+  #this in our data, so just change that one. 
+  #use_arabic_planet_numbering <- grepl("\\s+\\d+$", nationality$founding_name)
+  use_arabic_planet_numbering <- grepl("^Baker 3$", nationality$founding_name)
+  
   #get base name for numbering
   base_name <- ""
   if(use_roman_planet_numbering) {

--- a/functions/system_creation_functions.R
+++ b/functions/system_creation_functions.R
@@ -157,7 +157,7 @@ generate_system <- function(star=NULL, habitable=TRUE, habit_pos=NA) {
   previous_inhabitable <- FALSE
   #create a max habit slot to adjust for forced_canon_pos
   max_habit_slot <- habitable_slot
-  if(!is.na(force_canon_pos)) {
+  if(!is.na(force_canon_pos) & force_canon_pos>max_habit_slot) {
     max_habit_slot <- force_canon_pos
   }
   for(slot in 1:orbital_slots) {
@@ -165,7 +165,7 @@ generate_system <- function(star=NULL, habitable=TRUE, habit_pos=NA) {
     #If canon system position is chosen, then don't allow empty slots before
     #the canon system position. Also not before a forced canon position
     empty_ok <- (is.na(habit_pos) || slot>habit_pos) & 
-      (is.na(force_canon_pos) || slot>force_canon_pos)
+      (is.na(force_canon_pos) || (slot>max_habit_slot))
     
     planet <- generate_planet(orbital_placement[slot],slot==habitable_slot,
                               stype_data, allow_empty = empty_ok)

--- a/functions/system_creation_functions.R
+++ b/functions/system_creation_functions.R
@@ -12,27 +12,17 @@ load(here("output","habitable_zones.RData"))
 
 generate_system <- function(star=NULL, habitable=TRUE, habit_pos=NA) {
   
-  force_canon_pos <- NA
+  if(!is.null(star) && (is.na(star) || !is_star_valid(star))) {
+    warning("Star type of", star, "invalid")
+    star <- NULL
+  }
   
+  #check whether canon position is valid
+  force_canon_pos <- NA
   if(!is.null(star)) {
-    #break apart stype to make sure it makes sense
     spectral_class <- substr(star,1,1)
     subtype <- as.numeric(substr(star,2,2))
     star_size <- substring(star, 3)
-    
-    if(is.na(star_size) | !(spectral_class %in% c("A","B","F","G","K","M"))) {
-      warning("Invalid spectral class provided.")
-      star <- NULL
-    }
-    if(is.na(subtype) | subtype <0 | subtype>9) {
-      warning("Invalid subtype provided.")
-      star <- NULL
-    }
-    if(is.na(star_size) | nchar(star_size)==0 | 
-       !(star_size %in% c("Ia","Ib","II","III","IV","V","VI","VII"))) {
-      warning("Invalid star size provided.")
-      star <- NULL
-    }
     
     #what are the possible habitable positions for this star type?
     possible_hpos <- NA
@@ -46,14 +36,8 @@ generate_system <- function(star=NULL, habitable=TRUE, habit_pos=NA) {
     if(!is.na(habit_pos) && habitable && !(habit_pos %in% possible_hpos)) {
       #mismatch! Damn you FASA!
       #we want to keep the canonicity here even at the expense of SCIENCE, so
-      #we the plan is to generate a system as normal and then swap one of the
-      #inhabited slots with our canon position. There are two complications to consider
-      #with this.
-      #1 - we need a system with at least as many slots as the canon position, and probably
-      #    a few more to account for asteroid belts
-      #2 - we need to account for asteroid belts as they could occur between the actual
-      #    inhabited slot and the one we want. 
-      
+      #we generate a system as normal and then swap one of the inhabited slots with our canon position. 
+
       #change force_canon_pos to canon_pos
       force_canon_pos <- habit_pos
       
@@ -1199,6 +1183,19 @@ add_colonization <- function(system, distance_terra, current_year,
   return(system)
 }
 
+is_star_valid <- function(star) {
+  spectral_class <- substr(star,1,1)
+  subtype <- as.numeric(substr(star,2,2))
+  star_size <- substring(star, 3)
+  
+  if(is.na(spectral_class) || !(spectral_class %in% c("A","B","F","G","K","M")) | 
+     (is.na(subtype) || subtype <0 || subtype>9) |
+     (is.na(star_size) || nchar(star_size)==0 ||
+      !(star_size %in% c("Ia","Ib","II","III","IV","V","VI","VII")))) {
+    return(FALSE)
+  }
+  return(TRUE)
+}
 
 #### Population Projection Functions ####
 

--- a/input/planets.xml
+++ b/input/planets.xml
@@ -80131,10 +80131,10 @@ Alphard Trading Corporation [destroyed 3075]</desc>
         <id>Pesht</id>
         <name>Pesht</name>
         <sysPos>3</sysPos>
-        <spectralType>F7v</spectralType>
+        <spectralType>F7V</spectralType>
         <spectralClass>F</spectralClass>
         <subtype>7.0</subtype>
-        <luminosity>v</luminosity>
+        <luminosity>V</luminosity>
         <satellite>Buda</satellite>
         <gravity>1.04</gravity>
         <percentWater>64</percentWater>
@@ -82640,7 +82640,7 @@ The marketing campaign forgot to mention that there were fewer areas with modera
         <id>Proserpina</id>
         <name>Proserpina</name>
         <sysPos>4</sysPos>
-        <spectralType>K2v</spectralType>
+        <spectralType>K2V</spectralType>
         <spectralClass>K</spectralClass>
         <subtype>2.0</subtype>
         <luminosity>v</luminosity>
@@ -101611,8 +101611,8 @@ Earthwerks Incorporated</desc>
         <id>Tigress</id>
         <name>Tigress</name>
         <sysPos>4</sysPos>
-        <spectralType>?7V</spectralType>
-        <spectralClass>?</spectralClass>
+        <spectralType>G7V</spectralType>
+        <spectralClass>G</spectralClass>
         <subtype>7.0</subtype>
         <luminosity>V</luminosity>
         <satellite>Jarvic</satellite>

--- a/produce_systems.R
+++ b/produce_systems.R
@@ -275,10 +275,13 @@ for(i in 1:xml_length(planets)) {
   if(!is.na(roman)) {
     canon_pos <- convert_roman2arabic(roman)
   }
-  #now look for arabic numbering
-  arabic <- str_trim(str_extract(temp, "\\s+\\d+$"))
-  if(!is.na(arabic)) {
-    canon_pos <- as.numeric(arabic)
+  #now look for arabic numbering - it turns out this is problematic because it is used for 
+  #things like Star Cluster 643. The only valid case we have at the moment is Baker 3 so
+  #lets just look for that specifically
+  #arabic <- str_trim(str_extract(temp, "Baker 3$"))
+  #if(!is.na(arabic)) {
+  if(grepl("^Baker 3$", name)) {
+    canon_pos <- 3
   }
   if(!is.na(sys_pos)) {
     canon_pos <- sys_pos

--- a/produce_systems.R
+++ b/produce_systems.R
@@ -85,7 +85,7 @@ for(i in 1:xml_length(planets)) {
   cat(paste(id,"\n\treading in XML data..."))
   
   #system information
-  star <- toupper(xml_text(xml_find_first(planet, "spectralType")))
+  star <- xml_text(xml_find_first(planet, "spectralType"))
   sys_pos <- as.numeric(xml_text(xml_find_first(planet, "sysPos")))
   
   #planetary information - is this all Canon? 
@@ -225,20 +225,10 @@ for(i in 1:xml_length(planets)) {
   faction_type <- get_faction_type(faction)
   
   #Check for bad stellar types and correct
-  if(!is.na(star)) {
-    spectral_class <- substr(star,1,1)
-    subtype <- as.numeric(substr(star,2,2))
-    star_size <- substring(star, 3)
-    
-    if(is.na(star_size) | !(spectral_class %in% c("A","B","F","G","K","M")) | 
-       is.na(subtype) | subtype <0 | subtype>9 |
-       is.na(star_size) | nchar(star_size)==0 | 
-       !(star_size %in% c("Ia","Ib","II","III","IV","V","VI","VII"))) {
-      star <- NULL
-      warning(paste("Invalid star information provided for", id, star))
-    }
-    
-  } else {
+  if(is.na(star)) {
+   star <- NULL
+  } else if(!is_star_valid(star)) {
+    warning(paste("star type of", star, "not valid for", id))
     star <- NULL
   }
 

--- a/produce_systems.R
+++ b/produce_systems.R
@@ -235,6 +235,7 @@ for(i in 1:xml_length(planets)) {
        is.na(star_size) | nchar(star_size)==0 | 
        !(star_size %in% c("Ia","Ib","II","III","IV","V","VI","VII"))) {
       star <- NULL
+      warning(paste("Invalid star information provided for", id, star))
     }
     
   } else {

--- a/produce_systems.R
+++ b/produce_systems.R
@@ -286,10 +286,14 @@ for(i in 1:xml_length(planets)) {
   
   cat("done\n\tGenerating base system and colonization data...")
   
-  system <- generate_system_names(add_colonization(generate_system(star=star, habit_pos=canon_pos), 
-                                                   distance_terra, 3047, founding_year,
-                                                   faction_type, abandon_year), 
-                                  id)
+  #base system
+  system <- generate_system(star=star, habitable=TRUE, habit_pos=canon_pos)
+  #add colonization
+  system <- add_colonization(system, distance_terra, 3047, founding_year,
+                             faction_type, abandon_year)
+  #name stuff
+  system <- generate_system_names(system, id)
+  
   primary_slot <- which(system$planets$population==max(system$planets$population, na.rm=TRUE))[1]
   
   #### Output XML ####


### PR DESCRIPTION
This PR adds code that will allow canon system position to remain in cases where there is a mismatch between the canon system position and the life zone implied by the canon star type. In these cases, we make sure we create a system large enough for the canon system position and then swap its position with the actual inhabited world. 